### PR TITLE
lsf-L3-tracker#456 set timeout for google http request

### DIFF
--- a/hostProviders/google/src/main/java/com/ibm/spectrum/constant/GcloudConst.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/constant/GcloudConst.java
@@ -82,5 +82,11 @@ public class GcloudConst {
     public static final String BULK_INSERT_ID_PREFIX = "bulk-";
 
     public static final int MAXIMUM_VM_IN_ONE_REQUEST = 1000;
+    
+    // default http connect timeout 10 seconds
+    public static final int DEFAULT_HTTP_CONNECT_TIMEOUT = 10; 
+    
+    // default http read timeout 20 seconds
+    public static final int DEFAULT_HTTP_READ_TIMEOUT = 20;
 
 }

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/model/GcloudConfig.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/model/GcloudConfig.java
@@ -62,8 +62,22 @@ public class GcloudConfig {
      */
     @JsonProperty("GCLOUD_REGION")
     private String gcloudRegion;
-
+    
     /**
+     * Optional and type is int, specify the http connect timeout (in seconds)
+     */
+    @JsonProperty("HTTP_CONNECT_TIMEOUT")
+    @JsonInclude(Include.NON_NULL)
+    private Integer httpConnectTimeout;
+
+	/**
+     * Optional and type is int, specify the http read timeout (in seconds)
+     */
+    @JsonProperty("HTTP_READ_TIMEOUT")
+    @JsonInclude(Include.NON_NULL)
+    private Integer httpReadTimeout;
+ 
+	/**
     * <p>Title: </p>
     * <p>Description: </p>
     */
@@ -80,6 +94,9 @@ public class GcloudConfig {
         this.credentialFile = c.getCredentialFile();
         this.projectID = c.getProjectID();
         this.bulkInsertEnabled = c.getBulkInsertEnabled();
+        this.gcloudRegion = c.getGcloudRegion();
+        this.httpConnectTimeout = c.getHttpConnectTimeout();
+        this.httpReadTimeout = c.getHttpReadTimeout();
     }
 
     /**
@@ -156,6 +173,35 @@ public class GcloudConfig {
         this.gcloudRegion = gcloudRegion;
     }
 
+    
+    /**
+    * @return httpConnectTimeout
+    */
+    public Integer getHttpConnectTimeout() {
+		return httpConnectTimeout;
+	}
+
+    /**
+     * @param httpConnectTimeout to set (in seconds)
+     */
+	public void setHttpConnectTimeout(Integer httpConnectTimeout) {
+		this.httpConnectTimeout = httpConnectTimeout;
+	}
+
+    
+    /**
+    * @return httpReadTimeout
+    */
+    public Integer getHttpReadTimeout() {
+		return httpReadTimeout;
+	}
+
+    /**
+     * @param httpReadTimeout to set (in seconds)
+     */
+	public void setHttpReadTimeout(Integer httpReadTimeout) {
+		this.httpReadTimeout = httpReadTimeout;
+	}
 
 
     /** (Non Javadoc)
@@ -173,6 +219,12 @@ public class GcloudConfig {
         builder.append(credentialFile);
         builder.append(", projectID=");
         builder.append(projectID);
+        builder.append(", gcloudRegion=");
+        builder.append(gcloudRegion);
+        builder.append(", httpConnectTimeout=");
+        builder.append(httpConnectTimeout);
+        builder.append(", httpReadTimeout=");
+        builder.append(httpReadTimeout);
         if (bulkInsertEnabled != null) {
             builder.append(", bulkInsertEnabled=");
             builder.append(bulkInsertEnabled);

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/model/GcloudRequest.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/model/GcloudRequest.java
@@ -332,6 +332,8 @@ public class GcloudRequest {
         builder.append(vmName);
         builder.append(", machineId=");
         builder.append(machineId);
+        builder.append(", templateId=");
+        builder.append(templateId);
         builder.append(", gracePeriod=");
         builder.append(gracePeriod);
         builder.append(", rc_account=");

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
@@ -987,5 +987,43 @@ public class GcloudUtil {
             return false;
         }
     }
+    
+    /**
+     * @Title: getHttpRequestConnectTimeout
+     * @Description: get the google httpRequest connect timeout in seconds
+     * @param null
+     * @return httpRequest connect timeout
+     */
+    public static int getHttpRequestConnectTimeout() {
+		int connectTimeout = GcloudConst.DEFAULT_HTTP_CONNECT_TIMEOUT;
+
+    	Integer configConnectTimeout = GcloudUtil.getConfig().getHttpConnectTimeout();
+		if (configConnectTimeout != null && configConnectTimeout.intValue() > 0 && configConnectTimeout.intValue() < 60) {
+			connectTimeout = configConnectTimeout.intValue();
+		} else if (configConnectTimeout != null) {
+			log.warn("HTTP_CONNECT_TIMEOUT must be greater than 0 and smaller than 60. Set default to " + connectTimeout);
+		}
+		
+		return connectTimeout;
+    }
+    
+    /**
+     * @Title: getHttpRequestReadTimeout
+     * @Description: get the google httpRequest read timeout in seconds
+     * @param null
+     * @return httpRequest read timeout
+     */
+    public static int getHttpRequestReadTimeout() {
+		int readTimeout = GcloudConst.DEFAULT_HTTP_READ_TIMEOUT;
+		
+		Integer configReadTimeout = GcloudUtil.getConfig().getHttpReadTimeout();
+		if (configReadTimeout != null && configReadTimeout.intValue() > 0 && configReadTimeout.intValue() < 60) {
+			readTimeout = configReadTimeout.intValue();
+		} else if (configReadTimeout != null) {
+			log.warn("HTTP_READ_TIMEOUT must be greater than 0 and smaller than 60. Set default to " + readTimeout);
+		}
+
+		return readTimeout;
+    }
 
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
bug
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.ibm.com/platformcomputing/lsf-L3-tracker/issues/456
**DESCRIPTION**: -- symptom of the problem a customer would see
When use regional bulk request, it might return the read timeout error:
Create instance error. java.net.SocketTimeoutException: Read timed out

**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)
Over demand. And those created instances are out of control of LSF RC 
**HOW TO DETECT THE ERROR:**
closed_RC instances but the instances are RUNNING on google cloud.
**HOW TO WORKAROUND/AVOID THE ERROR:**
NA.
**HOW TO RECOVER FROM THE FAILURE:**
Manually delete those instance on google cloud.
**ROOT CAUSE OF THE PROBLEM:**
Google API httpRequest might timeout.
**UNIT TEST CASES:**

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```
