### PR TITLE
lsf-tracker#2700 instanceTags not work with launchTemplate

### DIFF
--- a/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/AwsImpl.java
+++ b/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/AwsImpl.java
@@ -233,10 +233,14 @@ public class AwsImpl implements IAws {
                             if (inst != null) {
                                 String state = inst.getState().getName();
                                 if (!state.equals(m.getStatus())) {
-                                    if (AwsConst.markedForTerminationStates.contains(m.getStatus()) &&
+                                    if ((AwsConst.markedForTerminationStates.contains(m.getStatus()) ||
+                                        "pending".equalsIgnoreCase(m.getStatus())) &&
                                             state.equalsIgnoreCase("running")) {
-                                        // Do not update instances that is still RUNNING but marked for termination
-                                        log.warn("Host <" + m.getMachineId() + "> last spot request status is <" + m.getStatus()
+                                        // Do not update the instance status
+                                        // 1. if it is still in running but marked for termination
+                                        // 2. if it first change from pending to running. getRequestStatus will 
+                                        // update its status, so that it can apply post behavior - tag the instance
+                                        log.info("Host <" + m.getMachineId() + "> last spot request status is <" + m.getStatus()
                                                  + ">, now it is in <" + state + ">");
                                     } else {
                                         log.debug("Host <" + m.getMachineId() + "> status changes from <" + m.getStatus()


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**DESCRIPTION**: -- symptom of the problem a customer would see
 instanceTags not work with launchTemplate. For aws, the tagSpecification can only work with runInstances API or EC2 Fleet instant type. If the request type is request, tagSpecification not work. What we can do is after the instnance is created successfully(the first time status change from "pending" to "running"), tag the instance.

**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)

**HOW TO DETECT THE ERROR:**
See the tag of instance or ebs on AWS console.

**HOW TO WORKAROUND/AVOID THE ERROR:**

**HOW TO RECOVER FROM THE FAILURE:**

**ROOT CAUSE OF THE PROBLEM:**

**UNIT TEST CASES:**

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```
