### PR TITLE
Try an alternate template when the provisioning API returns a Capacit…

### DIFF
--- a/hostProviders/ibmcloudgen2/scripts/nextgen_utils.py
+++ b/hostProviders/ibmcloudgen2/scripts/nextgen_utils.py
@@ -34,6 +34,7 @@ class RCInstance:
     self.retId = ""
     self.template = ""
     self.rcAccount = ""
+    self.statusReasons = []
 
   def copy(self, inst):
     self.machineId = inst.machineId
@@ -47,7 +48,8 @@ class RCInstance:
     self.retId = inst.retId
     self.template = inst.template
     self.rcAccount = inst.rcAccount
-   
+    self.statusReasons = inst.statusReasons   
+
   def populate(self, data):
     if 'machineId' in data:
       self.machineId = data['machineId']
@@ -71,6 +73,8 @@ class RCInstance:
       self.template = data['template']
     if 'rcAccount' in data:
       self.rcAccount = data['rcAccount']
+    if 'statusReasons' in data:
+      self.statusReasons = data['statusReasons']
    
   @property
   def machineId(self):
@@ -149,6 +153,13 @@ class RCInstance:
   def rcAccount(self, value):
     self._rcAccount = value
 
+  @property
+  def statusReasons(self):
+    return self._statusReasons
+  @statusReasons.setter
+  def statusReasons(self, value):
+    self._statusReasons = value
+
 class RcInOut:
 
   def __init__(self, dirname=""):
@@ -174,6 +185,7 @@ class RcInOut:
           'retId': retId if len(retId) != 0 else instance.retId,
           'template': instance.template if len(instance.template) != 0 else templateId,
           'rcAccount': instance.rcAccount,
+          'statusReasons': instance.statusReasons
       })
 
     return data


### PR DESCRIPTION
…y error code

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

**Which issue(s) this PR fixes**:
https://github.ibm.com/platformcomputing/lsf-tracker/issues/2821
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->

**DESCRIPTION**: -- symptom of the problem a customer would see
On IBM cloud, when LSF requests to provision VM instances, there will be no error while provisioning if the zone has capacity issues. We will get a 201 success. But if the requested zone has reached capacity, the instance will get status as failed with status reason code as cannot_start_capacity etc.

When LSF checks instances status for the certain provision request, if there is any instance’s status is failed with status reason code as the following ones. LSF will log the capacity errors in LSF logs and delete the failed VMs, then disable the corresponding template for the duration defined by LSB_RC_TEMPLATE_REQUEST_DELAY in lsf.conf and try other templates to feed demands.

**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)
LSF keep creating VM on template which cannot provision VM.

**HOW TO DETECT THE ERROR:**
NA

**HOW TO WORKAROUND/AVOID THE ERROR:**
NA

**HOW TO RECOVER FROM THE FAILURE:**
NA

**ROOT CAUSE OF THE PROBLEM:**
NA

**UNIT TEST CASES:**
fake VM status and status reason in plugin to simulate capacity issue to test the solution.

**TEST SUGGESTIONS TO QA:**
NA

**POSSIBLE IMPACT FEATURES:**
NA

```
