### PR TITLE
lsf-L3-tracker#736 avoid reclaim instances if failed to list all inst…

### DIFF
--- a/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/GcloudImpl.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/GcloudImpl.java
@@ -172,6 +172,15 @@ public class GcloudImpl implements IGcloud {
         // load information from DB and Google cloud
         GcloudEntity provisionStatusDB = GcloudUtil.getFromFile();
         Map<String, Instance> instances = GcloudClient.getCloudVMMap();
+        
+        /* lsf-L3-tracker#736 do not reclaim host if list all instances from cloud fail */
+        if (instances == null || instances.isEmpty()) {
+            rsp.setStatus(GcloudConst.EBROKERD_STATE_COMPLETE);
+            rsp.setReqs(gcloudRequestList);
+            rsp.setRsp(0, "Failed to list instances on Google Cloud");
+            log.warn("getReturnRequests failed because of failing to list instances on Google Cloud.");
+            return rsp; 
+        }
 
         List<GcloudRequest> requestsToBeChecked = new ArrayList<GcloudRequest>();
         if (provisionStatusDB != null && !CollectionUtils.isEmpty(provisionStatusDB.getReqs())) {

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/client/GcloudClient.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/client/GcloudClient.java
@@ -1417,7 +1417,7 @@ public class GcloudClient {
             log.trace("Start in class GcloudClient in method getCloudVMMap()");
         }
 
-        Map<String, Instance> vmMap = new HashMap<String, Instance>();
+        Map<String, Instance> vmMap = null;
         String projectId = GcloudUtil.getConfig().getProjectID();
 
         // Get instance list on cloud
@@ -1430,6 +1430,7 @@ public class GcloudClient {
 
         // Add these instances to vmMap
         if (CollectionUtils.isNotEmpty(instList)) {
+            vmMap =  new HashMap<String, Instance>();
             for (Instance inst : instList) {
                 vmMap.put(inst.getId().toString(), inst);
             }

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/client/GcloudClient.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/client/GcloudClient.java
@@ -1417,7 +1417,7 @@ public class GcloudClient {
             log.trace("Start in class GcloudClient in method getCloudVMMap()");
         }
 
-        Map<String, Instance> vmMap = null;
+        Map<String, Instance> vmMap = new HashMap<String, Instance>();
         String projectId = GcloudUtil.getConfig().getProjectID();
 
         // Get instance list on cloud
@@ -1430,7 +1430,6 @@ public class GcloudClient {
 
         // Add these instances to vmMap
         if (CollectionUtils.isNotEmpty(instList)) {
-            vmMap =  new HashMap<String, Instance>();
             for (Instance inst : instList) {
                 vmMap.put(inst.getId().toString(), inst);
             }

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
@@ -998,10 +998,10 @@ public class GcloudUtil {
 		int connectTimeout = GcloudConst.DEFAULT_HTTP_CONNECT_TIMEOUT;
 
     	Integer configConnectTimeout = GcloudUtil.getConfig().getHttpConnectTimeout();
-		if (configConnectTimeout != null && configConnectTimeout.intValue() > 0 && configConnectTimeout.intValue() < 60) {
+		if (configConnectTimeout != null && configConnectTimeout.intValue() > 0) {
 			connectTimeout = configConnectTimeout.intValue();
 		} else if (configConnectTimeout != null) {
-			log.warn("HTTP_CONNECT_TIMEOUT must be greater than 0 and smaller than 60. Set default to " + connectTimeout);
+			log.warn("HTTP_CONNECT_TIMEOUT must be greater than 0 . Set default to " + connectTimeout);
 		}
 		
 		return connectTimeout;
@@ -1017,10 +1017,10 @@ public class GcloudUtil {
 		int readTimeout = GcloudConst.DEFAULT_HTTP_READ_TIMEOUT;
 		
 		Integer configReadTimeout = GcloudUtil.getConfig().getHttpReadTimeout();
-		if (configReadTimeout != null && configReadTimeout.intValue() > 0 && configReadTimeout.intValue() < 60) {
+		if (configReadTimeout != null && configReadTimeout.intValue() > 0) {
 			readTimeout = configReadTimeout.intValue();
 		} else if (configReadTimeout != null) {
-			log.warn("HTTP_READ_TIMEOUT must be greater than 0 and smaller than 60. Set default to " + readTimeout);
+			log.warn("HTTP_READ_TIMEOUT must be greater than 0. Set default to " + readTimeout);
 		}
 
 		return readTimeout;

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
@@ -953,6 +953,10 @@ public class GcloudUtil {
 
     public static void dumpInstList(List<Instance> instList, String caller) {
         log.debug("Begin dumpInstList: " + caller);
+        if (instList == null || instList.isEmpty()) {
+        	log.debug("empty instList");
+        	return;
+        }
         for (Instance inst : instList) {
             log.debug("id:<" + inst.getId().toString() + "> name:<" + inst.getName() + " status:<" + inst.getStatus() + ">.");
         }
@@ -961,6 +965,11 @@ public class GcloudUtil {
 
     public static void dumpInstMap(Map<String, Instance> vmMap, String caller) {
         log.debug("Begin dumpInstMap: " + caller);
+        if (vmMap == null || vmMap.isEmpty()) {
+        	log.debug("empty vmMap");
+        	return;
+        }
+        
         for (Map.Entry<String, Instance> entry : vmMap.entrySet()) {
             String instId =  entry.getKey() ;
             Instance inst =  entry.getValue();


### PR DESCRIPTION
…ance from google cloud

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
bug
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.ibm.com/platformcomputing/lsf-L3-tracker/issues/736
**DESCRIPTION**: -- symptom of the problem a customer would see
If failed to list all instances on google cloud, the getReturnRequest interface will reclaim all the host from cloud.

**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)
All instances reclaimed due to google http read or connect timeout.
**HOW TO DETECT THE ERROR:**
From log:
```
[2023-04-05 11:29:59.273]-[ERROR]-[com.ibm.spectrum.gcloud.client.GcloudClient.getCloudVMMap(GcloudClient.java:1428)] Get instance list failed. java.net.SocketTimeoutException: connect timed out

or 

[2023-03-27 16:30:35.567]-[ERROR]-[com.ibm.spectrum.gcloud.client.GcloudClient.getCloudVMMap(GcloudClient.java:1407)] Get instance list failed. com.google.api.client.googleapis.json.GoogleJsonResponseException: 503 Service Unavailable
GET https://compute.googleapis.com/compute/v1/projects/arm-huntercpu-flav-cfp-dev/aggregated/instances
{
"code" : 503,
"errors" : [ {
"domain" : "global",
"message" : "Internal error. Please try again or contact Google Support. (Code: '5F7E4432E6CC1.A8C40C1.2705E910')",
"reason" : "backendError"
} ],
"message" : "Internal error. Please try again or contact Google Support. (Code: '5F7E4432E6CC1.A8C40C1.2705E910')"
}
```
**HOW TO WORKAROUND/AVOID THE ERROR:**
NA
**HOW TO RECOVER FROM THE FAILURE:**
NA
**ROOT CAUSE OF THE PROBLEM:**
Google http service is not stable. It might take long time to response.
The current fix:
1. Remove the limit of max 60s of  HTTP_READ_TIMEOUT and HTTP_CONNECT_TIMEOUT. End users can set it a larger value.
2. Do not reclaim instances if get instanced failed from google cloud:
getCloudVMMap->getInstanceList()->compute.instances().aggregatedList(projectId);
   Just log an warning message. Once Google http response become quick and stable, getReturnRquest will get sync.

**UNIT TEST CASES:**
I use fake code to do UT.
```
174         //Map<String, Instance> instances = GcloudClient.getCloudVMMap();
174         Map<String, Instance> instances = null;                        <--- fake code.
175 
176         /* lsf-L3-tracker#736 do not reclaim host if list all instances from cloud fail */
177         if (instances == null || instances.isEmpty()) {
178             rsp.setStatus(GcloudConst.EBROKERD_STATE_COMPLETE);
179             rsp.setReqs(gcloudRequestList);
180             rsp.setRsp(0, "Failed to list instances on Google Cloud");
181             log.warn("getReturnRequests failed because of failing to list instances on Google Cloud.");
182             return rsp;
183         }
```

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**



