### PR TITLE
[10.1.0] lsf-L3-tracker#814 add ASSIGN_SERVICE_ACCOUNT_FROM_LAUNCH_TEMPLATE

### DIFF
--- a/hostProviders/google/src/main/java/com/ibm/spectrum/model/GcloudConfig.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/model/GcloudConfig.java
@@ -77,6 +77,14 @@ public class GcloudConfig {
     @JsonInclude(Include.NON_NULL)
     private Integer httpReadTimeout;
  
+    /**
+     * Optional and type is boolean, specify the flag to true if want to assign the ServiceAccount inside InstanceTmplate to created instances
+     */
+    @JsonProperty("ASSIGN_SERVICE_ACCOUNT_FROM_LAUNCH_TEMPLATE")
+    @JsonInclude(Include.NON_NULL)
+    private Boolean assignInstTemplateServiceAccount;
+    
+ 
 	/**
     * <p>Title: </p>
     * <p>Description: </p>
@@ -84,7 +92,9 @@ public class GcloudConfig {
     public GcloudConfig() {
     }
 
-    /**
+
+
+	/**
     * <p>Title: </p>
     * <p>Description: </p>
     * @param t
@@ -202,6 +212,20 @@ public class GcloudConfig {
 	public void setHttpReadTimeout(Integer httpReadTimeout) {
 		this.httpReadTimeout = httpReadTimeout;
 	}
+	
+	/**
+	 * @return assignInstTemplateServiceAccount
+	 */	
+    public Boolean getAssignInstTemplateServiceAccount() {
+		return assignInstTemplateServiceAccount;
+	}
+
+    /**
+     * @param assignInstTemplateServiceAccount
+     */
+	public void setAssignInstTemplateServiceAccount(Boolean assignInstTemplateServiceAccount) {
+		this.assignInstTemplateServiceAccount = assignInstTemplateServiceAccount;
+	}
 
 
     /** (Non Javadoc)
@@ -228,6 +252,10 @@ public class GcloudConfig {
         if (bulkInsertEnabled != null) {
             builder.append(", bulkInsertEnabled=");
             builder.append(bulkInsertEnabled);
+        }
+        if (assignInstTemplateServiceAccount != null) {
+            builder.append(", assignInstTemplateServiceAccount=");
+            builder.append(assignInstTemplateServiceAccount);
         }
         builder.append("]");
         return builder.toString();

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
@@ -1034,5 +1034,19 @@ public class GcloudUtil {
 
 		return readTimeout;
     }
+    
+    /**
+     * @Title: isAssignInstTemplateServiceAccount
+     * @Description: 
+     * @param 
+     * @return true if set ASSIGN_SERVICE_ACCOUNT_FROM_LAUNCH_TEMPLATE to true
+     */
+    public static boolean isAssignInstTemplateServiceAccount() {
+		if (Boolean.TRUE.equals(config.getAssignInstTemplateServiceAccount())) {
+			return true;
+		}
+
+		return false;
+    }
 
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
feature
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.ibm.com/platformcomputing/lsf-L3-tracker/issues/814
**DESCRIPTION**: -- symptom of the problem a customer would see
Add a new parameter ASSIGN_SERVICE_ACCOUNT_FROM_LAUNCH_TEMPLATE in googleprov_config.json, if set to true,
if launchTemplate is defined in a LSF template, assign the "Service Account" inside the "Instance Template" to created instances.
If not set or set to false, assign the "default"  Service Account to created instances, with permission of "Compute Engine" and "Storage" access.
**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)

**HOW TO DETECT THE ERROR:**

**HOW TO WORKAROUND/AVOID THE ERROR:**
NA
**HOW TO RECOVER FROM THE FAILURE:**

**ROOT CAUSE OF THE PROBLEM:**

**UNIT TEST CASES:**
```
# vim ../conf/resource_connector/google/conf/googleprov_config.json
{
  "LogLevel": "TRACE",
  "GCLOUD_PROJECT_ID": "lsf-core-qa",
  "ASSIGN_SERVICE_ACCOUNT_FROM_LAUNCH_TEMPLATE": true,
  "HTTP_READ_TIMEOUT": 180,
  "HTTP_CONNECT_TIMEOUT": 120
}

# vim ../conf/resource_connector/google/conf/googleprov_templates.json
{
    "templates": [
        {   
            "templateId": "gcloud-VM-1",
            "maxNumber": 1,
            "attributes": {
                "type": ["String", "X86_64"],
                "ncores": ["Numeric", "1"],
                "ncpus": ["Numeric", "1"],
                "nthreads": ["Numeric", "2"],
                "define_ncpus_threads": ["Boolean", "1"],
                "mem": ["Numeric", "512"],
                "googlehost": ["Boolean", "1"]
            },
            "imageId": "lsf-gcloud-dynamic-vm",
            "region": "us-east1",
            "zone": "us-east1-d",
            "vmType": "n2-standard-2",
            "launchTemplateId" : "instance-ssd-zcg",
            "privateNetworkOnlyFlag": false,
            "vpc": "lsf-vpc",
            "priority": "18",
            "subnetId": "lsf-vpc-us-east1",
            "instanceTags" : "lsf-vpn-instance=gcloud-VM-1",
            "userData": "region=us_east1"
        },
        {    
            "templateId": "gcloud-VM-2",
            "maxNumber": 1,
            "attributes": {
                "type": ["String", "X86_64"],
                "ncores": ["Numeric", "2"],
                "ncpus": ["Numeric", "2"],
                "nthreads": ["Numeric", "2"],
                "mem": ["Numeric", "512"],
                "zone": ["String", "us_east1-d"],
                "googlehost": ["Boolean", "1"]
            },
            "region": "us-east1",
            "vmType": "n2-standard-2",         
            "imageId": "lsf-gcloud-dynamic-vm",
            "zone": "us-east1-d",
            "privateNetworkOnlyFlag": false,
            "vpc": "lsf-vpc",
            "priority": "10",
            "subnetId": "lsf-vpc-us-east1",
            "instanceTags" : "lsf-vpn-instance=gcloud-VM-2",
            "userData": "zone=us_east1-c"
        }
    ]
}

```
For gcloud-VM-1, its created instances will be assigned the "Service Account" from Instance Template of "instance-ssd-zcg".
For gcloud-VM-2, its created instances will be assigned the "Default" "Service Account".


**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```
