### PR TITLE
lsf-L3-tracker#875 prevent getReturnRequest fail when an templateId i…

### DIFF
--- a/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/GcloudImpl.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/gcloud/GcloudImpl.java
@@ -270,6 +270,7 @@ public class GcloudImpl implements IGcloud {
                 if (CollectionUtils.isEmpty(mList)) {
                     if (GcloudUtil.isBulkRequest(requestInDB.getHostAllocationType())) {
                         GcloudClient.updateBulkVMList(requestInDB, rsp);
+                        log.debug("Bulk request status: " + requestInDB);
                         if (requestInDB.getStatus() != null
                                 && (requestInDB.getStatus().equals(GcloudConst.EBROKERD_STATE_COMPLETE)
                                     || requestInDB.getStatus().equals(GcloudConst.EBROKERD_STATE_COMPLETE_WITH_ERROR))
@@ -656,7 +657,7 @@ public class GcloudImpl implements IGcloud {
             if (GcloudUtil.isBulkRequest(fReq.getHostAllocationType())
                     && statusUpdateForCreateMachine) {
                 vmMap = GcloudClient.updateBulkVMList(fReq, rsp);
-                if (vmMap == null) {
+                if (vmMap == null || vmMap.isEmpty()) {
                     return;
                 }
                 machinesListInDB = fReq.getMachines();

--- a/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
+++ b/hostProviders/google/src/main/java/com/ibm/spectrum/util/GcloudUtil.java
@@ -683,6 +683,7 @@ public class GcloudUtil {
             }
         }
 
+        log.warn("Failed to getTemplateFromFile " + templateId);
         return null;
     }
 


### PR DESCRIPTION
…s removed

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.ibm.com/platformcomputing/lsf-L3-tracker/issues/875
**DESCRIPTION**: -- symptom of the problem a customer would see
Prevent getReturnRequest fail when an templateId is removed from googleprov_templates.json.

**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)
getReturnRequest interface fail, so that ebrokerd cannot detect instances reclaim by cloud, and mbd cannot relinquish the host.

**HOW TO DETECT THE ERROR:**
ebrokerd log and google.provider.log.
**HOW TO WORKAROUND/AVOID THE ERROR:**
1. Add the missing template back.
2. Remove the issue request from google-db.json

**HOW TO RECOVER FROM THE FAILURE:**

**ROOT CAUSE OF THE PROBLEM:**

**UNIT TEST CASES:**
Add an issue request into google-db.json with non-exist templateId.
{
    "time" : 1692855518349,
    "machines" : [ ],
    "requestId" : "operation-1692855517172-603a4a3c1d4ff-becfc259-53efae73",
    "templateId" : "gcloud-VM-3",        <------ non existing.
    "rc_account" : "default",
    "hostAllocationType" : "ZonalBulk",
    "bulkInsertId" : "bulk-29ee7057-032d-488d-86bd-24c3c6b08292"
  }

getReturnRequest will not fail.
[2023-08-25 04:38:02.547]-[DEBUG]-[com.ibm.spectrum.gcloud.client.GcloudClient.updateBulkVMList(GcloudClient.java:1231)] Start in class GcloudClient in method updateBulkVMList with parameters: GcloudRequest: GcloudRequest [reqId=operation-1692855517172-603a4a3c1d4ff-becfc259-53efae73, msg=null, status=null, ttl=null, time=1692855518349, machines=[], vmName=null, machineId=null, templateId=gcloud-VM-3, gracePeriod=null, rc_account=default, allocationtype=ZonalBulk, bulkInsertId=bulk-29ee7057-032d-488d-86bd-24c3c6b08292]
[2023-08-25 04:38:02.552]-[WARN]-[com.ibm.spectrum.util.GcloudUtil.getTemplateFromFile(GcloudUtil.java:686)] Failed to getTemplateFromFile gcloud-VM-3
[2023-08-25 04:38:02.552]-[WARN]-[com.ibm.spectrum.gcloud.client.GcloudClient.updateBulkVMList(GcloudClient.java:1242)] Failed to get template gcloud-VM-3
[2023-08-25 04:38:02.552]-[DEBUG]-[com.ibm.spectrum.gcloud.GcloudImpl.getReturnRequests(GcloudImpl.java:273)] Bulk request status: GcloudRequest [reqId=operation-1692855517172-603a4a3c1d4ff-becfc259-53efae73, msg=null, status=complete_with_error, ttl=null, time=1692855518349, machines=[], vmName=null, machineId=null, templateId=gcloud-VM-3, gracePeriod=null, rc_account=default, allocationtype=ZonalBulk, bulkInsertId=bulk-29ee7057-032d-488d-86bd-24c3c6b08292]
[2023-08-25 04:38:02.552]-[DEBUG]-[com.ibm.spectrum.gcloud.GcloudImpl.getReturnRequests(GcloudImpl.java:278)] Bulk request <operation-1692855517172-603a4a3c1d4ff-becfc259-53efae73> is empty. Remove it from the DB.
[2023-08-25 04:38:02.553]-[TRACE]-[com.ibm.spectrum.gcloud.client.GcloudClient.retrieveInstancesMarkedForTermination(GcloudClient.java:907)] [getReturnRequest]Start in class GcloudClient in method getInstancesStatus with parameters: requestsList: [GcloudRequest [reqId=operation-1692854948784-603a481e0e872-2415d621-003cd213, msg=null, status=complete, ttl=null, time=1692854950154, machines=[], vmName=null, machineId=null, templateId=gcloud-VM-1, gracePeriod=null, rc_account=default, allocationtype=ZonalBulk, bulkInsertId=bulk-0c8bead4-2e13-4b49-9b12-1b75352f5a14], GcloudRequest [reqId=operation-1692938165673-603b7e1fddd7f-fc602339-7183f8c4, msg=null, status=null, ttl=null, time=1692938167182, machines=[GcloudMachine [machineId=1906195175869616472, name=compute-ct2wc0001, privateIpAddress=10.20.2.36, publicIpAddress=104.196.47.13, publicDnsName=, rc_account=default, reqId=operation-1692938165673-603b7e1fddd7f-fc602339-7183f8c4, retId=null, operationId=operation-1692938165673-603b7e1fddd7f-fc602339-7183f8c4, template=gcloud-VM-1, zone=us-east1-d, launchtime=1692938166, result=succeed, msg=, status=RUNNING]], vmName=null, machineId=null, templateId=gcloud-VM-1, gracePeriod=null, rc_account=default, allocationtype=ZonalBulk, bulkInsertId=bulk-d906c38d-27ea-47ce-bc11-3794da7e0f97]]
[2023-08-25 04:38:02.553]-[TRACE]-[com.ibm.spectrum.gcloud.client.GcloudClient.retrieveInstancesMarkedForTermination(GcloudClient.java:914)] [getReturnRequest]End in class GcloudClient in method getInstancesStatus with return: void: null
[2023-08-25 04:38:02.582]-[INFO]-[com.ibm.spectrum.GcloudMain.call(GcloudMain.java:155)] Call method: [getReturnRequests] end, response: GcloudEntity [code=0, msg=Instances marked for termination retrieved successfully, reqId=null, retId=null, status=complete, template=null, machine=null, request=null, templates=null, machines=null, reqs=[], rc_account=null, userData=null]

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```
