### PR TITLE
bulk tag request

### DIFF
--- a/hostProviders/aws/postprovision/lsf/example_user_data.sh
+++ b/hostProviders/aws/postprovision/lsf/example_user_data.sh
@@ -13,7 +13,7 @@ echo START `date '+%Y-%m-%d %H:%M:%S'` >> $logfile
 # Add your customization script here
 #
 
-# By default TAG_INSTANCEID is unenabled in awsprov_config.json.
+# By default AWS_TAG_InstanceID is unenabled in awsprov_config.json.
 # Uncomment following lines If you still want to tag 
 # both instance and ebs volumes with "InstnceID".
 # NOTE: It is required to install AWS CLI in your compute image.

--- a/hostProviders/aws/postprovision/lsf/example_user_data.sh
+++ b/hostProviders/aws/postprovision/lsf/example_user_data.sh
@@ -13,6 +13,19 @@ echo START `date '+%Y-%m-%d %H:%M:%S'` >> $logfile
 # Add your customization script here
 #
 
+# By default TAG_INSTANCEID is unenabled in awsprov_config.json.
+# Uncomment following lines If you still want to tag 
+# both instance and ebs volumes with "InstnceID".
+# NOTE: It is required to install AWS CLI in your compute image.
+#
+#echo "tagging InstanceID to both instance and ebs volumes" >> $logfile
+#AWS_INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+#ROOT_DISK_ID=`aws ec2 describe-volumes --filter Name=attachment.instance-id,Values="${AWS_INSTANCE_ID}" --query "Volumes[*].[VolumeId]"  --out text`
+#aws ec2 create-tags --resources "${AWS_INSTANCE_ID}" "${ROOT_DISK_ID}" --tags "Key=InstanceID,Value=${AWS_INSTANCE_ID}"
+#if [ $? -eq 0 ]; then
+#    echo "Done tagging InstanceID ${AWS_INSTANCE_ID} to instance and ebs volumes $ROOT_DISK_ID" >> $logfile
+#fi
+
 #
 # Source LSF enviornment at the VM host
 #

--- a/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/client/AWSClient.java
+++ b/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/client/AWSClient.java
@@ -1488,7 +1488,7 @@ public class AWSClient {
             log.trace("Creating the following tags: " + tagsToBeCreated);
 
             createTagsRequest.withResources(resourceIds)
-            .withTags(tagsToBeCreated);
+                             .withTags(tagsToBeCreated);
             CreateTagsResult createTagsResult = ec2.createTags(createTagsRequest);
             log.trace("Result tag: " + createTagsResult);
             if (log.isTraceEnabled()) {

--- a/hostProviders/aws/src/main/java/com/ibm/spectrum/model/AwsConfig.java
+++ b/hostProviders/aws/src/main/java/com/ibm/spectrum/model/AwsConfig.java
@@ -98,7 +98,7 @@ public class AwsConfig {
      *          both the instance and its ebs volumes.
      * if false, AWS plugin will not add "InstanceID" to new created instances.
      */
-    @JsonProperty("TAG_INSTANCEID")
+    @JsonProperty("AWS_TAG_InstanceID")
     @JsonInclude(Include.NON_NULL)
     private Boolean tagInstanceID = new Boolean(false);
 

--- a/hostProviders/aws/src/main/java/com/ibm/spectrum/model/AwsConfig.java
+++ b/hostProviders/aws/src/main/java/com/ibm/spectrum/model/AwsConfig.java
@@ -93,6 +93,16 @@ public class AwsConfig {
     private Integer instanceCreationTimeout;
 
     /**
+     * Optional and type is Boolean (true/false). Default: false.
+     * if true, AWS plugin will add the tag of "InstanceID" to new created instances on
+     *          both the instance and its ebs volumes.
+     * if false, AWS plugin will not add "InstanceID" to new created instances.
+     */
+    @JsonProperty("TAG_INSTANCEID")
+    @JsonInclude(Include.NON_NULL)
+    private Boolean tagInstanceID = new Boolean(false);
+
+	/**
     * <p>Title: </p>
     * <p>Description: </p>
     */
@@ -225,6 +235,15 @@ public class AwsConfig {
         this.instanceCreationTimeout = instanceCreationTimeout;
     }
 
+    public Boolean getTagInstanceID() {
+        return tagInstanceID;
+    }
+
+    public void setTagInstanceID(Boolean tagInstanceID) {
+        this.tagInstanceID = tagInstanceID;
+    }
+
+
     /** (Non Javadoc)
     * <p>Title: toString</p>
     * <p>Description: </p>
@@ -250,6 +269,8 @@ public class AwsConfig {
         builder.append(spotTerminateOnReclaim);
         builder.append(", instanceCreationTimeout=");
         builder.append(instanceCreationTimeout);
+        builder.append(", tagInstanceID=");
+        builder.append(tagInstanceID);
         builder.append("]");
         return builder.toString();
     }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.ibm.com/platformcomputing/lsf-tracker/issues/3722

**DESCRIPTION**: -- symptom of the problem a customer would see
bulk tag request.

**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)
Originally instance tagging is per-instance level. It does tagging for each instance in getRequestStatus->applyPostCreationBehaviorForInstance() when each instance become "running" status.

This fix bult tagging request to per-request level, i.e. template+rc_account level.  It bulk the tagging request of all instances and its ebs volumes into 500 resources per-batch. 

**IMPORTANT NOTE: The tag of InstanceID is removed from the tag list. The reason is that InstanceID tag value is different with each other, it has to be instance-level. I would consider to move it to user-data.sh or preProvScript.**




**HOW TO DETECT THE ERROR:**

**HOW TO WORKAROUND/AVOID THE ERROR:**

**HOW TO RECOVER FROM THE FAILURE:**

**ROOT CAUSE OF THE PROBLEM:**

**UNIT TEST CASES:**

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```
