### PR TITLE
[10.1.0] bulk tag request

### DIFF
--- a/hostProviders/aws/postprovision/lsf/example_user_data.sh
+++ b/hostProviders/aws/postprovision/lsf/example_user_data.sh
@@ -13,6 +13,19 @@ echo START `date '+%Y-%m-%d %H:%M:%S'` >> $logfile
 # Add your customization script here
 #
 
+# By default AWS_TAG_InstanceID is unenabled in awsprov_config.json.
+# Uncomment following lines If you still want to tag 
+# both instance and ebs volumes with "InstnceID".
+# NOTE: It is required to install AWS CLI in your compute image.
+#
+#echo "tagging InstanceID to both instance and ebs volumes" >> $logfile
+#AWS_INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+#ROOT_DISK_ID=`aws ec2 describe-volumes --filter Name=attachment.instance-id,Values="${AWS_INSTANCE_ID}" --query "Volumes[*].[VolumeId]"  --out text`
+#aws ec2 create-tags --resources "${AWS_INSTANCE_ID}" "${ROOT_DISK_ID}" --tags "Key=InstanceID,Value=${AWS_INSTANCE_ID}"
+#if [ $? -eq 0 ]; then
+#    echo "Done tagging InstanceID ${AWS_INSTANCE_ID} to instance and ebs volumes $ROOT_DISK_ID" >> $logfile
+#fi
+
 #
 # Source LSF enviornment at the VM host
 #

--- a/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/AwsImpl.java
+++ b/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/AwsImpl.java
@@ -790,6 +790,8 @@ public class AwsImpl implements IAws {
         AwsTemplate usedTemplate = AwsUtil.getTemplateFromFile(fReq.getTemplateId());
         List<String> vmIdLst = new ArrayList<String>();
         List<AwsMachine> newlyCreatedMachines = new ArrayList<AwsMachine>();
+        List<Instance> postCreationInstList = new ArrayList<Instance>();
+
         inReq.setReqId(fReq.getReqId());
         String latestRequestStatus = AwsConst.EBROKERD_STATE_COMPLETE;
         // If this is a Spot Fleet Request and the request update is for a create request, call the Spot Fleet APIs to update the status
@@ -915,8 +917,15 @@ public class AwsImpl implements IAws {
 
             //If the machine's status changed to running, apply the post creation behavior
             if("running".equalsIgnoreCase(latestMachineStatus) && !latestMachineStatus.equalsIgnoreCase(tempMachineOldStatus)) {
-                log.debug("[Instance - " + inReq.getReqId() + " - " + tempMachineInDB.getReqId() + " - " + tempMachineInDB.getMachineId() +"] Machine is successfully initiated. Running the post creation flow...");
-                AWSClient.applyPostCreationBehaviorForInstance(fReq, correspondingInstanceForTempMachineInDB, usedTemplate);
+                log.debug("[Instance - " + inReq.getReqId() + " - " + tempMachineInDB.getReqId() + " - " + tempMachineInDB.getMachineId()
+                           +"] Machine is successfully initiated. Ready for post creation behavior..");
+                if (! AwsUtil.getConfig().getTagInstanceID().booleanValue()) {
+                     // Do not need tag "InstanceID", then we can do batch tagging in later applyPostCreationBehaviorForInstanceList
+                     postCreationInstList.add(correspondingInstanceForTempMachineInDB);
+                } else {
+                     // Need tag "InstanceID", tag instance one by one now.
+                     AWSClient.applyPostCreationBehaviorForInstance(fReq, correspondingInstanceForTempMachineInDB, usedTemplate);
+                }
             }
             tempMachineInDB.setStatus(latestMachineStatus);
             tempMachineInDB.setPublicIpAddress(correspondingInstanceForTempMachineInDB.getPublicIpAddress());
@@ -930,6 +939,11 @@ public class AwsImpl implements IAws {
 
         }
 
+        if ((! AwsUtil.getConfig().getTagInstanceID().booleanValue()) &&
+            (! CollectionUtils.isNullOrEmpty(postCreationInstList))) {
+            AWSClient.applyPostCreationBehaviorForInstanceList(fReq, postCreationInstList, usedTemplate);
+            log.debug("[ Running the post creation flow for instances:" + postCreationInstList.toString());
+        }
         // 'running','complete','complete_with_error'
         log.debug("Setting the machine list to the response: " + machinesListInDB);
         inReq.setMachines(machinesListInDB);

--- a/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/client/AWSClient.java
+++ b/hostProviders/aws/src/main/java/com/ibm/spectrum/aws/client/AWSClient.java
@@ -715,6 +715,51 @@ public class AWSClient {
 
     }
 
+    /**
+     * Retrieves the list of tags that are needed to be attached to the
+     * instance, EBS volumes, .... <br>
+     * The default tags to be created are: <br>
+     * - Key: RC_ACCOUNT ; Value: {accountTagValue}
+     *
+     * Additional tags can be provided in the {additionalInstanceTags} parameter
+     * in the following format: {Key1=Value1;Key2=Value2}
+     *
+     * @param instanceTags
+     *            instanceTag defined in LSF template
+     * @param accountTagValue
+     *            The value of the RC_ACCOUNT tag
+     */
+    private static List<Tag> createTagsForInstanceCreation(
+        String instanceTags,
+        String accountTagValue) {
+        if (log.isTraceEnabled()) {
+            log.trace("Start in class AWSClient in method createTagsForInstanceCreation with parameters:"
+                      + "instanceTags: "
+                      + instanceTags
+                      + ", accountTagValue: "
+                      + accountTagValue);
+        }
+
+        // First create tag based on LSF template instanceTags
+        List<Tag> tags = createInstanceTags(instanceTags);
+
+        try {
+            Tag tag = null;
+            if (!StringUtils.isNullOrEmpty(accountTagValue)) {
+                tag = new Tag("RC_ACCOUNT", accountTagValue);
+                tags.add(tag);
+            }
+
+        } catch (Exception e) {
+            log.error("Create tag failed for accountTagValue: " + accountTagValue
+                      + " ] with the following error: " + e.getMessage(), e);
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("End in class AWSClient in method createTagsForInstanceCreation with return: tags: " + tags);
+        }
+        return tags;
+    }
 
     /**
      * Retrieves the list of tags that are needed to be attached to the
@@ -752,8 +797,6 @@ public class AWSClient {
         if (instance != null) {
             String instanceId = instance.getInstanceId();
             try {
-                String[] instanceTagStr = null;
-
                 Tag tag = null;
                 if (!StringUtils.isNullOrEmpty(accountTagValue)) {
                     tag = new Tag("RC_ACCOUNT", accountTagValue);
@@ -1364,6 +1407,102 @@ public class AWSClient {
     }
 
 
+    /**
+    *
+    * @Title: tagResources
+    * @Description: tag a list of resourceIds.
+    *         If resources number exceed 500, it will break into several request each with 500 resources.
+    * @param @param resourceIds,tagValue
+    * @param @return
+    * @return void
+    * @throws
+    */
+    public static void tagResources(List<String> resourceIdList,  List<Tag> tagsToBeCreated) {
+        if (log.isTraceEnabled()) {
+            log.trace("Start in class AWSClient in method tagEbsVolumes with parameters: resourceIdList: " + resourceIdList + ", tagsToBeCreated: "
+                      + tagsToBeCreated);
+        }
+
+        if (CollectionUtils.isNullOrEmpty(resourceIdList)) {
+            return;
+        }
+
+        try {
+            /* Refer: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/CreateTagsRequest.html
+             * CreateTagsRequest:
+             * Constraints: Up to 1000 resource IDs. We recommend breaking up this request into smaller batches.
+            */
+            int MX_RESOURCES_NUM = 500;
+
+            log.trace("Creating tags with resource IDs: " + resourceIdList.toString());
+            log.trace("Creating the following tags: " + tagsToBeCreated);
+
+            List<String> resourceIdsInLoop = new ArrayList<String>();
+            for (String resourceId: resourceIdList) {
+                resourceIdsInLoop.add(resourceId);
+                if (resourceIdsInLoop.size() >= MX_RESOURCES_NUM) {
+                    tagResourcesOneBatch(resourceIdsInLoop, tagsToBeCreated);
+                    resourceIdsInLoop.clear();
+                }
+            }
+
+            if (! CollectionUtils.isNullOrEmpty(resourceIdsInLoop)) {
+                tagResourcesOneBatch(resourceIdsInLoop, tagsToBeCreated);
+            }
+
+            if (log.isTraceEnabled()) {
+                log.trace("End in class AWSClient in method tagResources with return: void: ");
+            }
+
+        } catch (AmazonServiceException ase) {
+            log.error("Tag resources list error." + ase.getMessage(),ase);
+        } catch (AmazonClientException ace) {
+            log.error("Tag  resources list error." + ace.getMessage(),ace);
+        } catch(Exception e) {
+            log.error("Tag  resources list error.", e);
+        }
+    }
+
+
+    /**
+    *
+    * @Title: tagResourcesOneBatch
+    * @Description: tag a list of resourceIds less than 500.
+    * @param @param resourceIds,tagValue
+    * @param @return
+    * @return void
+    * @throws
+    */
+    private static void tagResourcesOneBatch(List<String> resourceIds, List<Tag> tagsToBeCreated) {
+        if (log.isTraceEnabled()) {
+            log.trace("Start in class AWSClient in method tagEbsVolumes with parameters: resourceIds: " + resourceIds + ", tagsToBeCreated: "
+                      + tagsToBeCreated);
+        }
+        AmazonEC2 ec2 = getEC2Client();
+
+
+        try {
+            CreateTagsRequest createTagsRequest = new CreateTagsRequest();
+
+            log.trace("Creating tags with resource IDs: " + resourceIds);
+            log.trace("Creating the following tags: " + tagsToBeCreated);
+
+            createTagsRequest.withResources(resourceIds)
+                             .withTags(tagsToBeCreated);
+            CreateTagsResult createTagsResult = ec2.createTags(createTagsRequest);
+            log.trace("Result tag: " + createTagsResult);
+            if (log.isTraceEnabled()) {
+                log.trace("End in class AWSClient in method tagResourcesOneBatch with return: void: ");
+            }
+
+        } catch (AmazonServiceException ase) {
+            log.error("Tag volume error." + ase.getMessage(),ase);
+        } catch (AmazonClientException ace) {
+            log.error("Tag volume error." + ace.getMessage(),ace);
+        } catch(Exception e) {
+            log.error("Tag volume error.", e);
+        }
+    }
 
     /**
      *
@@ -2057,12 +2196,43 @@ public class AWSClient {
             log.trace("Start in class AWSClient in method applyPostCreationBehaviorForInstanceList with parameters: newInstances: "
                       + newInstances);
         }
-        if (!CollectionUtils.isNullOrEmpty(newInstances)) {
-            for (Instance instance : newInstances) {
-                applyPostCreationBehaviorForInstance(awsRequest, instance, usedTemplate);
+        if (CollectionUtils.isNullOrEmpty(newInstances)) {
+            if (log.isTraceEnabled()) {
+                log.trace("End in class AWSClient in method applyPostCreationBehaviorForInstanceLis. No instances need tagged ");
+            }
+            return;
+        }
+
+        List<Tag> tagsToBeCreated = createTagsForInstanceCreation(
+                usedTemplate.getInstanceTags(),
+                awsRequest.getTagValue());
+        log.trace("Creating the following tags: " + tagsToBeCreated);
+
+        List<String> resourceIdList = new ArrayList<String>();
+        for (Instance instance : newInstances) {
+            String instanceId = instance.getInstanceId();
+            List<String> ebsIds = new ArrayList<String>();
+
+            List<InstanceBlockDeviceMapping> mappingList = instance.getBlockDeviceMappings();
+            for (InstanceBlockDeviceMapping mapping: mappingList) {
+                 if (mapping != null)	 {
+                     EbsInstanceBlockDevice ebs = mapping.getEbs();
+                     log.trace(mapping);
+                     if (ebs != null) {
+                        if (!StringUtils.isNullOrEmpty(ebs.getVolumeId())) {
+                            ebsIds.add(ebs.getVolumeId());
+                        }
+                    }
+                }
             }
 
+            resourceIdList.add(instanceId);
+            resourceIdList.addAll(ebsIds);
+            log.trace("Add to resourceIdList of instance" + instanceId +" Ebs Volumes: " + ebsIds);
         }
+
+        tagResources(resourceIdList, tagsToBeCreated);
+
         if (log.isTraceEnabled()) {
             log.trace("End in class AWSClient in method applyPostCreationBehaviorForInstanceList with return: void: ");
         }

--- a/hostProviders/aws/src/main/java/com/ibm/spectrum/model/AwsConfig.java
+++ b/hostProviders/aws/src/main/java/com/ibm/spectrum/model/AwsConfig.java
@@ -93,6 +93,16 @@ public class AwsConfig {
     private Integer instanceCreationTimeout;
 
     /**
+     * Optional and type is Boolean (true/false). Default: false.
+     * if true, AWS plugin will add the tag of "InstanceID" to new created instances on
+     *          both the instance and its ebs volumes.
+     * if false, AWS plugin will not add "InstanceID" to new created instances.
+     */
+    @JsonProperty("AWS_TAG_InstanceID")
+    @JsonInclude(Include.NON_NULL)
+    private Boolean tagInstanceID = new Boolean(false);
+
+	/**
     * <p>Title: </p>
     * <p>Description: </p>
     */
@@ -225,6 +235,15 @@ public class AwsConfig {
         this.instanceCreationTimeout = instanceCreationTimeout;
     }
 
+    public Boolean getTagInstanceID() {
+        return tagInstanceID;
+    }
+
+    public void setTagInstanceID(Boolean tagInstanceID) {
+        this.tagInstanceID = tagInstanceID;
+    }
+
+
     /** (Non Javadoc)
     * <p>Title: toString</p>
     * <p>Description: </p>
@@ -250,6 +269,8 @@ public class AwsConfig {
         builder.append(spotTerminateOnReclaim);
         builder.append(", instanceCreationTimeout=");
         builder.append(instanceCreationTimeout);
+        builder.append(", tagInstanceID=");
+        builder.append(tagInstanceID);
         builder.append("]");
         return builder.toString();
     }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.ibm.com/platformcomputing/lsf-tracker/issues/3722

**DESCRIPTION**: -- symptom of the problem a customer would see
bulk tag request.

**IMPACT**: -- impact of problem in customer env (best/worse case scenarios)
Originally instance tagging is per-instance level. It does tagging for each instance in getRequestStatus->applyPostCreationBehaviorForInstance() when each instance become "running" status.

This fix bult tagging request to per-request level, i.e. template+rc_account level.  It bulk the tagging request of all instances and its ebs volumes into 500 resources per-batch. 

**IMPORTANT NOTE: The tag of InstanceID is removed from the tag list. The reason is that InstanceID tag value is different with each other, it has to be instance-level. I would consider to move it to user-data.sh or preProvScript.**




**HOW TO DETECT THE ERROR:**

**HOW TO WORKAROUND/AVOID THE ERROR:**

**HOW TO RECOVER FROM THE FAILURE:**

**ROOT CAUSE OF THE PROBLEM:**

**UNIT TEST CASES:**

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```
