### PR TITLE
Dedicated Host support for IBM Cloud

### DIFF
--- a/hostProviders/ibmcloudgen2/scripts/nextgen_rc_config.py
+++ b/hostProviders/ibmcloudgen2/scripts/nextgen_rc_config.py
@@ -157,6 +157,7 @@ class NextGenTemplate:
     self.sshkey_id = ""
     self.region = ""
     self.zone = ""
+    self.dedicatedHostGroupId = ""
     self.maxNumber = 0
     self.userData = ""
     self.crn = ""
@@ -188,6 +189,8 @@ class NextGenTemplate:
           self.region = template["region"]
         if "zone" in template:
           self.zone = template["zone"]
+        if "dedicatedHostGroupId" in template:
+          self.dedicatedHostGroupId = template["dedicatedHostGroupId"]
         if "userData" in template:
           self.userData = template["userData"]
         if "crn" in template:
@@ -273,6 +276,13 @@ class NextGenTemplate:
     self._zone = value
 
   @property
+  def dedicatedHostGroupId(self):
+    return self._dedicatedHostGroupId
+  @dedicatedHostGroupId.setter
+  def dedicatedHostGroupId(self, value):
+    self._dedicatedHostGroupId = value  
+
+  @property
   def userData(self):
     return self._userData
   @userData.setter
@@ -304,6 +314,7 @@ class NextGenTemplate:
           "sshkey_id: " + self.sshkey_id + "\n" + \
           "region: " + self.region + "\n" + \
           "zone: " + self.zone + "\n" + \
+          "dedicatedHostGroupId: " + self.dedicatedHostGroupId + "\n" + \
           "crn: " + self.crn + "\n" + \
           "volumeProfile: " + self.volumeProfile + "\n" + \
           "userData: " + self.userData 

--- a/hostProviders/ibmcloudgen2/scripts/vpc_vm_dns.py
+++ b/hostProviders/ibmcloudgen2/scripts/vpc_vm_dns.py
@@ -111,7 +111,7 @@ def NextGenVPCInit(_config, _template):
   config = _config
   template = _template
 
-def create_instance(rg, vpc, profile, zone, image, subnet, sgs, ssh_id, templateUserData, tagValue, templateId, instance_name, userDataFile, crn, volumeProfile):
+def create_instance(rg, vpc, profile, zone, dedicatedHostGroupId, image, subnet, sgs, ssh_id, templateUserData, tagValue, templateId, instance_name, userDataFile, crn, volumeProfile):
   # Construct a dict representation of a SecurityGroupIdentityById model
   security_group_identity_model_list = []
   for id in sgs:
@@ -125,6 +125,11 @@ def create_instance(rg, vpc, profile, zone, image, subnet, sgs, ssh_id, template
     subnet_identity_model['crn'] = subnet
   else:
     subnet_identity_model['id'] = subnet
+
+  # Construct a dict representation of a DedicatedHostGroupById model
+  if dedicatedHostGroupId:
+    dedicated_host_group_identity_model = {}
+    dedicated_host_group_identity_model['id'] = dedicatedHostGroupId
 
   # Construct a dict representation of a ImageIdentityById model
   image_identity_model = {}
@@ -178,6 +183,8 @@ def create_instance(rg, vpc, profile, zone, image, subnet, sgs, ssh_id, template
   instance_prototype_model = {}
   if crn:
     instance_prototype_model['boot_volume_attachment'] = instance_boot_vol_model
+  if dedicatedHostGroupId:
+    instance_prototype_model['placement_target'] = dedicated_host_group_identity_model
   instance_prototype_model['keys'] = [key_identity_model]
   instance_prototype_model['name'] = instance_name
   instance_prototype_model['profile'] = instance_profile_identity_model
@@ -234,6 +241,7 @@ def create_multi_instances(args):
              vsi.vpcId,
              vsi.vmType,
              vsi.zone,
+             vsi.dedicatedHostGroupId,
              vsi.imageId,
              vsi.subnetId,
              vsi.securityGroupId,


### PR DESCRIPTION
**What type of PR is this?**
**Feature**: Ability to spin dynamic compute hosts on existing dedicated hosts by providing a dedicated host group id.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #[4057](https://github.ibm.com/platformcomputing/lsf-tracker/issues/4057)

**DESCRIPTION**: -- symptom of the problem a customer would see
For clients that rely on autoscaling and for bursting use cases, provisioning virtual servers of the
right profile needs to be guaranteed. Due to capacity issue, IBM Cloud cannot guarantee creation
of virtual servers at given point. One way to tackle the IBM Cloud infrastructure limitation is to
provide that guarantee for LSF Resource Connector is to have ability to spin dynamic compute
hosts on existing dedicated hosts by providing a dedicated host group id that’s been already
created.

**IMPACT**: -- Provide an ability to spin dynamic compute hosts on existing dedicated hosts by providing a dedicated host group id.

**HOW TO DETECT THE ERROR:**
NA

**HOW TO WORKAROUND/AVOID THE ERROR:**
NA

**HOW TO RECOVER FROM THE FAILURE:**
NA

**ROOT CAUSE OF THE PROBLEM:**
NA

**UNIT TEST CASES:**
When dedicatedHostGroupId parameter in ibmcloudgen2_templates.json template file is set to
non-empty valid dedicated host group id, it should spin up the VM instances on one of the
dedicated hosts that belongs to provided dedicated host group id successfully.

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```
