### PR TITLE
Azure compute gallery image support for Azure RC

### DIFF
--- a/hostProviders/azure/src/main/java/com/ibm/spectrum/model/AzureTemplate.java
+++ b/hostProviders/azure/src/main/java/com/ibm/spectrum/model/AzureTemplate.java
@@ -59,6 +59,9 @@ public class AzureTemplate {
     private String imageId;
 
     @JsonInclude(Include.NON_NULL)
+    private String imageName;
+
+    @JsonInclude(Include.NON_NULL)
     private String storageAccountType;
 
     @JsonInclude(Include.NON_NULL)
@@ -188,6 +191,7 @@ public class AzureTemplate {
     public AzureTemplate(AzureTemplate t) {
         this.templateId = t.getTemplateId();
         this.imageId = t.getImageId();
+        this.imageName = t.getImageName();
         this.storageAccountType = t.storageAccountType;
         this.vmType = t.getVmType();
         this.vmNumber = t.getVmNumber();
@@ -261,6 +265,19 @@ public class AzureTemplate {
         this.imageId = imageId;
     }
 
+    /**
+    * @return imageName
+    */
+    public String getImageName() {
+        return imageName;
+    }
+
+    /**
+     * @param imageName the imageName to set
+     */
+    public void setImageName(String imageName) {
+        this.imageName = imageName;
+    }
 
     /**
     * @return vmType
@@ -505,6 +522,8 @@ public class AzureTemplate {
         builder.append(attributes);
         builder.append(", imageId=");
         builder.append(imageId);
+        builder.append(", imageName=");
+        builder.append(imageName);
         builder.append(", storageAccountType=");
         builder.append(storageAccountType);
         builder.append(", vmType=");

--- a/hostProviders/azure/src/main/java/com/ibm/spectrum/util/AzureUtil.java
+++ b/hostProviders/azure/src/main/java/com/ibm/spectrum/util/AzureUtil.java
@@ -776,7 +776,7 @@ public class AzureUtil {
             throw new IllegalArgumentException("Either imageId or imageName must be provided.");
         }
 
-        return String.format("{ \"id\": \"%s\" }", imageReferenceId);
+        return imageReferenceId;
     }
 
     /**
@@ -905,7 +905,7 @@ public class AzureUtil {
             }
             validateAndAddJsonNode("object", mapper.readTree(mapper.writeValueAsString(tags)), "tagValues", null, tmp);
             validateAndAddFieldValue("string", netSg.name(), "networkSecurityGroups", null, tmp);
-            validateAndAddFieldValue("string", imageRefJson, "imageReference", null, tmp);
+            validateAndAddFieldValue("string", imageRefJson, "imageId", null, tmp);
             validateAndAddFieldValue("string", t.getSubnetName(), "subnetName", null, tmp);
             validateAndAddFieldValue("string", t.getResourceGroup(), "virtualNetworkResourceGroup", null, tmp);
             validateAndAddFieldValue("string", t.getVirtualNetwork(), "virtualNetworkName", null, tmp);

--- a/hostProviders/azure/src/main/java/com/ibm/spectrum/util/AzureUtil.java
+++ b/hostProviders/azure/src/main/java/com/ibm/spectrum/util/AzureUtil.java
@@ -691,12 +691,12 @@ public class AzureUtil {
     }
 
     /**
-     * @Title: getImageReferenceJson
+     * @Title: getImage
      * @Description: get lsf image from either custom image or compute galleries on Azure
      * @param
-     * @return JSON string representing the image reference
+     * @return string representing the image reference
      */
-    public static String getImageReferenceJson(AzureTemplate t) {
+    public static String getImage(AzureTemplate t) {
         String imageId = t.getImageId();
         String imageName = t.getImageName();  // assumed to be a full resource ID
 
@@ -835,8 +835,8 @@ public class AzureUtil {
                 return null;
             }
             // Handle image reference with imageId taking precedence
-            String imageRefJson = getImageReferenceJson(t);
-            if (imageRefJson == null) {
+            String imageRef = getImage(t);
+            if (imageRef == null) {
                 log.error("No valid image reference could be created");
                 return null;
             }
@@ -905,7 +905,7 @@ public class AzureUtil {
             }
             validateAndAddJsonNode("object", mapper.readTree(mapper.writeValueAsString(tags)), "tagValues", null, tmp);
             validateAndAddFieldValue("string", netSg.name(), "networkSecurityGroups", null, tmp);
-            validateAndAddFieldValue("string", imageRefJson, "imageId", null, tmp);
+            validateAndAddFieldValue("string", imageRef, "imageId", null, tmp);
             validateAndAddFieldValue("string", t.getSubnetName(), "subnetName", null, tmp);
             validateAndAddFieldValue("string", t.getResourceGroup(), "virtualNetworkResourceGroup", null, tmp);
             validateAndAddFieldValue("string", t.getVirtualNetwork(), "virtualNetworkName", null, tmp);

--- a/hostProviders/azure/src/main/resources/template.json
+++ b/hostProviders/azure/src/main/resources/template.json
@@ -62,10 +62,10 @@
               "Description": "Tagvalues where resource used"
             }
         },
-        "imageReference": {
+        "imageId": {
             "type": "string",
             "metadata": {
-              "Description": "JSON string containing image reference (either custom image or gallery image)."
+              "Description": "Specify virtual machine image id (custom image or azure compute gallery image) which will be used to provision virtual machine."
             }
         },
         "postScriptUri": {
@@ -98,7 +98,6 @@
         "vnetId": "[resourceId(parameters('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('subnetName'))]",
         "networkInterfaceName": "[parameters('networkInterfaceName')]",
-        "parsedImageReference": "[json(parameters('imageReference'))]",
         "osDiskName": "[concat(parameters('virtualMachineName'), '-osdisk')]",
         "extensionName": "[concat(parameters('virtualMachineName'), '/ext')]",
         "post-script": {
@@ -138,10 +137,12 @@
                     "vmSize": "[parameters('virtualMachineSize')]"
                 },
                 "storageProfile": {
-                    "imageReference": "[variables('parsedImageReference')]",
+                    "imageReference": {
+                        "id": "[parameters('imageId')]"
+                    },
                     "osDisk": {
                         "name": "[variables('osDiskName')]",
-                        "createOption": "FromImage",
+                        "createOption": "fromImage",
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
                         }

--- a/hostProviders/azure/src/main/resources/template.json
+++ b/hostProviders/azure/src/main/resources/template.json
@@ -62,10 +62,10 @@
               "Description": "Tagvalues where resource used"
             }
         },
-        "imageId": {
+        "imageReference": {
             "type": "string",
             "metadata": {
-              "Description": "Specify virtual machine image id which will be used to provision virtual machine."
+              "Description": "JSON string containing image reference (either custom image or gallery image)."
             }
         },
         "postScriptUri": {
@@ -98,6 +98,7 @@
         "vnetId": "[resourceId(parameters('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('subnetName'))]",
         "networkInterfaceName": "[parameters('networkInterfaceName')]",
+        "parsedImageReference": "[json(parameters('imageReference'))]",
         "osDiskName": "[concat(parameters('virtualMachineName'), '-osdisk')]",
         "extensionName": "[concat(parameters('virtualMachineName'), '/ext')]",
         "post-script": {
@@ -111,7 +112,7 @@
         {
             "name": "[parameters('virtualMachineName')]",
             "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2021-03-01",
             "location": "[variables('location')]",
             "tags": "[parameters('tagValues')]",
             "dependsOn": [
@@ -137,12 +138,10 @@
                     "vmSize": "[parameters('virtualMachineSize')]"
                 },
                 "storageProfile": {
-                    "imageReference": {
-                        "id": "[parameters('imageId')]"
-                    },
+                    "imageReference": "[variables('parsedImageReference')]",
                     "osDisk": {
                         "name": "[variables('osDiskName')]",
-                        "createOption": "fromImage",
+                        "createOption": "FromImage",
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
                         }

--- a/hostProviders/azure/src/main/resources/templateWithPublicIp.json
+++ b/hostProviders/azure/src/main/resources/templateWithPublicIp.json
@@ -62,10 +62,10 @@
               "Description": "Tagvalues where resource used"
             }
         },
-        "imageReference": {
+        "imageId": {
             "type": "string",
             "metadata": {
-              "Description": "JSON string containing image reference (either custom image or gallery image)."
+              "Description": "Specify virtual machine image id (custom image or azure compute gallery image) which will be used to provision virtual machine."
             }
         },
         "postScriptUri": {
@@ -104,7 +104,6 @@
         "vnetId": "[resourceId(parameters('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('subnetName'))]",
         "networkInterfaceName": "[parameters('networkInterfaceName')]",
-        "parsedImageReference": "[json(parameters('imageReference'))]",
         "osDiskName": "[concat(parameters('virtualMachineName'), '-osdisk')]",
         "extensionName": "[concat(parameters('virtualMachineName'), '/ext')]",
         "post-script": {
@@ -144,10 +143,12 @@
                     "vmSize": "[parameters('virtualMachineSize')]"
                 },
                 "storageProfile": {
-                    "imageReference": "[variables('parsedImageReference')]",
+                    "imageReference": {
+                        "id": "[parameters('imageId')]"
+                    },
                     "osDisk": {
                         "name": "[variables('osDiskName')]",
-                        "createOption": "FromImage",
+                        "createOption": "fromImage",
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
                         }

--- a/hostProviders/azure/src/main/resources/templateWithPublicIp.json
+++ b/hostProviders/azure/src/main/resources/templateWithPublicIp.json
@@ -62,10 +62,10 @@
               "Description": "Tagvalues where resource used"
             }
         },
-        "imageId": {
+        "imageReference": {
             "type": "string",
             "metadata": {
-              "Description": "Specify virtual machine image id which will be used to provision virtual machine."
+              "Description": "JSON string containing image reference (either custom image or gallery image)."
             }
         },
         "postScriptUri": {
@@ -104,6 +104,7 @@
         "vnetId": "[resourceId(parameters('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('subnetName'))]",
         "networkInterfaceName": "[parameters('networkInterfaceName')]",
+        "parsedImageReference": "[json(parameters('imageReference'))]",
         "osDiskName": "[concat(parameters('virtualMachineName'), '-osdisk')]",
         "extensionName": "[concat(parameters('virtualMachineName'), '/ext')]",
         "post-script": {
@@ -117,7 +118,7 @@
         {
             "name": "[parameters('virtualMachineName')]",
             "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2021-03-01",
             "location": "[variables('location')]",
             "tags": "[parameters('tagValues')]",
             "dependsOn": [
@@ -143,12 +144,10 @@
                     "vmSize": "[parameters('virtualMachineSize')]"
                 },
                 "storageProfile": {
-                    "imageReference": {
-                        "id": "[parameters('imageId')]"
-                    },
+                    "imageReference": "[variables('parsedImageReference')]",
                     "osDisk": {
                         "name": "[variables('osDiskName')]",
-                        "createOption": "fromImage",
+                        "createOption": "FromImage",
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
                         }


### PR DESCRIPTION
**What type of PR is this?**
**Feature**: Ability to spin dynamic compute hosts using azure compute galleries images.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #[4023](https://github.ibm.com/platformcomputing/lsf-tracker/issues/4023)

**DESCRIPTION**: -- symptom of the problem a customer would see
For clients that rely on resource connector for Azure to deploy virtual machines as dynamic
compute nodes, Azure encouraged to use Azure Compute Gallery. All new features, like ARM64,
Trusted Launch, and Confidential VM are only supported through Azure Compute Gallery.

**IMPACT**: -- Provide an ability to spin dynamic compute hosts using azure compute galleries images using parameter named imageName.

**HOW TO DETECT THE ERROR:**
NA

**HOW TO WORKAROUND/AVOID THE ERROR:**
NA

**HOW TO RECOVER FROM THE FAILURE:**
NA

**ROOT CAUSE OF THE PROBLEM:**
NA

**UNIT TEST CASES:**
When imageName parameter in azureprov_templates.json template file is set to non-empty valid image name (resource id) of either custom image or azure compute galleries, it should spin up the VM instances successfully.

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```