### PR TITLE
Azure compute gallery image support for Azure RC (#82)

### DIFF
--- a/hostProviders/azure/src/main/java/com/ibm/spectrum/model/AzureTemplate.java
+++ b/hostProviders/azure/src/main/java/com/ibm/spectrum/model/AzureTemplate.java
@@ -59,6 +59,9 @@ public class AzureTemplate {
     private String imageId;
 
     @JsonInclude(Include.NON_NULL)
+    private String imageName;
+
+    @JsonInclude(Include.NON_NULL)
     private String storageAccountType;
 
     @JsonInclude(Include.NON_NULL)
@@ -188,6 +191,7 @@ public class AzureTemplate {
     public AzureTemplate(AzureTemplate t) {
         this.templateId = t.getTemplateId();
         this.imageId = t.getImageId();
+        this.imageName = t.getImageName();
         this.storageAccountType = t.storageAccountType;
         this.vmType = t.getVmType();
         this.vmNumber = t.getVmNumber();
@@ -261,6 +265,19 @@ public class AzureTemplate {
         this.imageId = imageId;
     }
 
+    /**
+    * @return imageName
+    */
+    public String getImageName() {
+        return imageName;
+    }
+
+    /**
+     * @param imageName the imageName to set
+     */
+    public void setImageName(String imageName) {
+        this.imageName = imageName;
+    }
 
     /**
     * @return vmType
@@ -505,6 +522,8 @@ public class AzureTemplate {
         builder.append(attributes);
         builder.append(", imageId=");
         builder.append(imageId);
+        builder.append(", imageName=");
+        builder.append(imageName);
         builder.append(", storageAccountType=");
         builder.append(storageAccountType);
         builder.append(", vmType=");

--- a/hostProviders/azure/src/main/resources/template.json
+++ b/hostProviders/azure/src/main/resources/template.json
@@ -65,7 +65,7 @@
         "imageId": {
             "type": "string",
             "metadata": {
-              "Description": "Specify virtual machine image id which will be used to provision virtual machine."
+              "Description": "Specify virtual machine image id (custom image or azure compute gallery image) which will be used to provision virtual machine."
             }
         },
         "postScriptUri": {
@@ -111,7 +111,7 @@
         {
             "name": "[parameters('virtualMachineName')]",
             "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2021-03-01",
             "location": "[variables('location')]",
             "tags": "[parameters('tagValues')]",
             "dependsOn": [

--- a/hostProviders/azure/src/main/resources/templateWithPublicIp.json
+++ b/hostProviders/azure/src/main/resources/templateWithPublicIp.json
@@ -65,7 +65,7 @@
         "imageId": {
             "type": "string",
             "metadata": {
-              "Description": "Specify virtual machine image id which will be used to provision virtual machine."
+              "Description": "Specify virtual machine image id (custom image or azure compute gallery image) which will be used to provision virtual machine."
             }
         },
         "postScriptUri": {
@@ -117,7 +117,7 @@
         {
             "name": "[parameters('virtualMachineName')]",
             "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2021-03-01",
             "location": "[variables('location')]",
             "tags": "[parameters('tagValues')]",
             "dependsOn": [


### PR DESCRIPTION
**What type of PR is this?**
**Feature**: Ability to spin dynamic compute hosts using azure compute galleries images.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #[4023](https://github.ibm.com/platformcomputing/lsf-tracker/issues/4023)

**DESCRIPTION**: -- symptom of the problem a customer would see
For clients that rely on resource connector for Azure to deploy virtual machines as dynamic
compute nodes, Azure encouraged to use Azure Compute Gallery. All new features, like ARM64,
Trusted Launch, and Confidential VM are only supported through Azure Compute Gallery.

**IMPACT**: -- Provide an ability to spin dynamic compute hosts using azure compute galleries images using parameter named imageName.

**HOW TO DETECT THE ERROR:**
NA

**HOW TO WORKAROUND/AVOID THE ERROR:**
NA

**HOW TO RECOVER FROM THE FAILURE:**
NA

**ROOT CAUSE OF THE PROBLEM:**
NA

**UNIT TEST CASES:**
When imageName parameter in azureprov_templates.json template file is set to non-empty valid image name (resource id) of either custom image or azure compute galleries, it should spin up the VM instances successfully.

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```