### PR TITLE
Managed Identity auth support for Azure (#84)

### DIFF
--- a/hostProviders/azure/conf/lsf/azureprov_config.json
+++ b/hostProviders/azure/conf/lsf/azureprov_config.json
@@ -1,5 +1,6 @@
 {
-  "LogLevel": "INFO",  
+  "LogLevel": "INFO",
+  "AZURE_MANAGED_IDENTITY": "N",
   "AZURE_CREDENTIAL_FILE": "/home/lsfadmin/credentials",
   "AZURE_REGION": "southeastasia"
 }

--- a/hostProviders/azure/src/main/java/com/ibm/spectrum/model/AzureConfig.java
+++ b/hostProviders/azure/src/main/java/com/ibm/spectrum/model/AzureConfig.java
@@ -40,7 +40,14 @@ public class AzureConfig {
     private String logLevel;
 
     /**
-     * Required and type is string, specify the Path of the credentials file
+     * Optional and type is string, specify Y|y|N|n as a valid value
+     * which expect managed identity to be configured manually if set to Y or y
+     */
+    @JsonProperty("AZURE_MANAGED_IDENTITY")
+    private String AzureManagedIdentity;
+
+    /**
+     * Optional and type is string, specify the Path of the credentials file
      * which has the access key and secret key information
      */
     @JsonProperty("AZURE_CREDENTIAL_FILE")
@@ -92,6 +99,7 @@ public class AzureConfig {
      */
     public AzureConfig(AzureConfig c) {
         this.logLevel = c.getLogLevel();
+        this.AzureManagedIdentity = c.getAzureManagedIdentity();
         this.AzureCredentialFile = c.getAzureCredentialFile();
         this.AzureRegion = c.getAzureRegion();
         this.AzureKeyFile = c.getAzureKeyFile();
@@ -110,6 +118,21 @@ public class AzureConfig {
      */
     public void setLogLevel(String logLevel) {
         this.logLevel = logLevel;
+    }
+
+    /**
+     * @return AzureManagedIdentity
+     */
+    public String getAzureManagedIdentity() {
+        return AzureManagedIdentity;
+    }
+
+    /**
+     * @param AzureManagedIdentity
+     *            the AzureManagedIdentity to set
+     */
+    public void setAzureManagedIdentity(String AzureManagedIdentity) {
+        this.AzureManagedIdentity = AzureManagedIdentity;
     }
 
     /**
@@ -189,6 +212,8 @@ public class AzureConfig {
         StringBuilder builder = new StringBuilder();
         builder.append("AzureConfig [logLevel=");
         builder.append(logLevel);
+        builder.append(", AzureManagedIdentity=");
+        builder.append(AzureManagedIdentity);
         builder.append(", AzureCredentialFile=");
         builder.append(AzureCredentialFile);
         builder.append(", AzureRegion=");


### PR DESCRIPTION
**What type of PR is this?**
**Feature**: Ability to spin dynamic compute hosts using azure managed identity authentication.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <repo name>#<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #[4066](https://github.ibm.com/platformcomputing/lsf-tracker/issues/4066)

**DESCRIPTION**: -- symptom of the problem is currently the only method of authentication in the resource connector involves storing the credentials in a credential file in the LSF is AZURE_CREDENTIAL_FILE parameter within the Azure configuration file. However, storing credentials in a plain text file is strongly discouraged due to security concerns. To avoid the security issues, we are supporting more secure way to provide required authentication required for resource connector.

**IMPACT**: -- Provide an ability to spin dynamic compute hosts using azure managed identity authentication using new parameter named AZURE_MANAGED_IDENTITY.

**HOW TO DETECT THE ERROR:**
NA

**HOW TO WORKAROUND/AVOID THE ERROR:**
NA

**HOW TO RECOVER FROM THE FAILURE:**
NA

**ROOT CAUSE OF THE PROBLEM:**
NA

**UNIT TEST CASES:**
When AZURE_MANAGED_IDENTITY parameter in azureprov_config.json template file is set to Y or y,  with managed identity service configured manually, it should spin up the VM instances successfully.

**TEST SUGGESTIONS TO QA:**

**POSSIBLE IMPACT FEATURES:**


```